### PR TITLE
Add new service /converter

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import dotenv from 'dotenv';
 import crons from './crons';
 import { cache, error } from './middlewares';
 import {
-  backup, latest, status, symbols, timeline,
+  backup, converter, latest, status, symbols, timeline,
 } from './services';
 import PKG from '../package.json';
 
@@ -29,6 +29,7 @@ global.connections = {};
 // -- Middlewares
 app.get('/:baseCurrency/:symbol/:group', cache, timeline);
 app.get('/:baseCurrency/latest', cache, latest);
+app.get('/convert/:baseCurrency/:amount/:symbol', converter);
 app.get('/symbols', cache, symbols);
 app.get('/status', status);
 app.get('/backup/:key', backup);

--- a/src/index.js
+++ b/src/index.js
@@ -29,7 +29,7 @@ global.connections = {};
 // -- Middlewares
 app.get('/:baseCurrency/:symbol/:group', cache, timeline);
 app.get('/:baseCurrency/latest', cache, latest);
-app.get('/convert/:baseCurrency/:amount/:symbol', converter);
+app.get('/convert/:baseCurrency/:amount/:symbol', cache, converter);
 app.get('/symbols', cache, symbols);
 app.get('/status', status);
 app.get('/backup/:key', backup);

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,7 @@ import dotenv from 'dotenv';
 import crons from './crons';
 import { cache, error } from './middlewares';
 import {
-  backup, converter, latest, status, symbols, timeline,
+  backup, convert, latest, status, symbols, timeline,
 } from './services';
 import PKG from '../package.json';
 
@@ -29,7 +29,7 @@ global.connections = {};
 // -- Middlewares
 app.get('/:baseCurrency/:symbol/:group', cache, timeline);
 app.get('/:baseCurrency/latest', cache, latest);
-app.get('/convert/:baseCurrency/:amount/:symbol', cache, converter);
+app.get('/convert/:baseCurrency/:amount/:symbol', cache, convert);
 app.get('/symbols', cache, symbols);
 app.get('/status', status);
 app.get('/backup/:key', backup);

--- a/src/services/convert.js
+++ b/src/services/convert.js
@@ -28,8 +28,8 @@ export default (req, res) => {
     latestRate[BASE_CURRENCY] = parseCurrency(conversion);
   }
 
-  // 4. Calculate the rate with the amount
-  const rate = latestRate[baseCurrency] * amount;
+  // 4. Calculate the value with the amount
+  const value = latestRate[baseCurrency] * amount;
 
   // 5. cache & response
   const response = {
@@ -38,7 +38,7 @@ export default (req, res) => {
     amount,
     date,
     hour,
-    rate,
+    value,
   };
 
   cache.set(originalUrl, response);

--- a/src/services/converter.js
+++ b/src/services/converter.js
@@ -1,0 +1,46 @@
+import {
+  C, cache, exchange, ERROR, parseCurrency, time, Store,
+} from '../common';
+
+const { BASE_CURRENCY, SYMBOLS } = C;
+
+export default (req, res) => {
+  const { originalUrl, params: { amount, baseCurrency, symbol } } = req;
+  const { date } = time();
+
+  // 1. Control if it's baseCurrency and symbol are allowed values
+  if (!SYMBOLS.includes(baseCurrency) || !SYMBOLS.includes(symbol)) return ERROR.NOT_FOUND(res);
+
+  // 2. Get values
+  const store = new Store({ filename: date.substr(0, 7) });
+  const rates = store.read();
+  const hour = Object.keys(rates[date])
+    .sort()
+    .reverse()
+    .find((item) => Object.keys(rates[date][item]).length > 168);
+
+  const latestRate = rates[date][hour];
+
+  // 3. If base currency is not the default one convert it
+  if (symbol !== BASE_CURRENCY) {
+    const conversion = 1 / latestRate[symbol];
+    latestRate[baseCurrency] = exchange(baseCurrency, latestRate[baseCurrency], conversion);
+    latestRate[BASE_CURRENCY] = parseCurrency(conversion);
+  }
+
+  // 4. Calculate the rate with the amount
+  const rate = latestRate[baseCurrency] * amount;
+
+  // 5. cache & response
+  const response = {
+    baseCurrency,
+    symbol,
+    amount,
+    date,
+    hour,
+    rate,
+  };
+
+  cache.set(originalUrl, response);
+  res.json(response);
+};

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,5 +1,5 @@
 import backup from './backup';
-import converter from './converter';
+import convert from './convert';
 import latest from './latest';
 import status from './status';
 import symbols from './symbols';
@@ -7,7 +7,7 @@ import timeline from './timeline';
 
 export {
   backup,
-  converter,
+  convert,
   latest,
   status,
   symbols,

--- a/src/services/index.js
+++ b/src/services/index.js
@@ -1,4 +1,5 @@
 import backup from './backup';
+import converter from './converter';
 import latest from './latest';
 import status from './status';
 import symbols from './symbols';
@@ -6,6 +7,7 @@ import timeline from './timeline';
 
 export {
   backup,
+  converter,
   latest,
   status,
   symbols,


### PR DESCRIPTION
This PR adds a new service `converter` which receives a `baseCurrency`, an `amount` and a `symbol`, it returns the amount of base currency converted to the symbol value, for example:

`/convert/BTC/1/EUR` would be _How many euros is a BTC_

`BTC` is the `baseCurrency`, `1` is the `amount` and `EUR` is the `symbol`

The response would be:

```json
{
  "baseCurrency": "EUR",
  "symbol": "BTC",
  "amount": "9095",
  "date": "2019-10-04",
  "hour": "06",
  "rate": 0.9999043
}
```